### PR TITLE
Depend on bullet-cpp and check that bullet collision detector is built and fix linking of fcl and assimp on Windows

### DIFF
--- a/recipe/1510.patch
+++ b/recipe/1510.patch
@@ -1,0 +1,66 @@
+From 2ed57ec92624080e1661441e1572b867378d0f5f Mon Sep 17 00:00:00 2001
+From: Silvio Traversaro <silvio@traversaro.it>
+Date: Sat, 17 Oct 2020 02:20:05 +0200
+Subject: [PATCH] Fix MSVC linking for assimp and fcl (#1510)
+
+Co-authored-by: Jeongseok Lee <jslee02@users.noreply.github.com>
+---
+ cmake/Findassimp.cmake | 9 +++++++--
+ cmake/Findfcl.cmake    | 9 +++++++--
+ 2 files changed, 14 insertions(+), 4 deletions(-)
+
+diff --git a/cmake/Findassimp.cmake b/cmake/Findassimp.cmake
+index 3063d6d20cb..07b4a417385 100644
+--- a/cmake/Findassimp.cmake
++++ b/cmake/Findassimp.cmake
+@@ -26,7 +26,10 @@ find_path(ASSIMP_INCLUDE_DIRS assimp/scene.h
+ 
+ # Libraries
+ if(MSVC)
+-  set(ASSIMP_LIBRARIES "assimp$<$<CONFIG:Debug>:d>")
++  find_package(assimp QUIET CONFIG)
++  if(TARGET assimp::assimp)
++    set(ASSIMP_LIBRARIES "assimp::assimp")
++  endif()
+ else()
+   find_library(ASSIMP_LIBRARIES
+       NAMES assimp
+@@ -34,7 +37,9 @@ else()
+ endif()
+ 
+ # Version
+-set(ASSIMP_VERSION ${PC_ASSIMP_VERSION})
++if(PC_ASSIMP_VERSION)
++  set(ASSIMP_VERSION ${PC_ASSIMP_VERSION})
++endif()
+ 
+ # Set (NAME)_FOUND if all the variables and the version are satisfied.
+ include(FindPackageHandleStandardArgs)
+diff --git a/cmake/Findfcl.cmake b/cmake/Findfcl.cmake
+index e49de2cadb2..5f586c675dc 100644
+--- a/cmake/Findfcl.cmake
++++ b/cmake/Findfcl.cmake
+@@ -28,7 +28,10 @@ find_path(FCL_INCLUDE_DIRS
+ 
+ # Libraries
+ if(MSVC)
+-  set(FCL_LIBRARIES "fcl$<$<CONFIG:Debug>:d>")
++  find_package(fcl QUIET CONFIG)
++  if(TARGET fcl)
++    set(FCL_LIBRARIES fcl)
++  endif()
+ else()
+   # Give explicit precedence to ${PC_FCL_LIBDIR}
+   find_library(FCL_LIBRARIES
+@@ -44,7 +47,9 @@ else()
+ endif()
+ 
+ # Version
+-set(FCL_VERSION ${PC_FCL_VERSION})
++if(PC_FCL_VERSION)
++  set(FCL_VERSION ${PC_FCL_VERSION})
++endif()
+ 
+ # Set (NAME)_FOUND if all the variables and the version are satisfied.
+ include(FindPackageHandleStandardArgs)
+ 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
       - ode-required.patch
 
 build:
-  number: 3
+  number: 4
   run_exports:
     - {{ pin_subpackage(name, max_pin='x.x') }}
 
@@ -46,7 +46,7 @@ requirements:
   run:
     - assimp
     - boost-cpp
-    - bullet
+    - bullet-cpp
     - console_bridge
     - eigen
     - fcl
@@ -64,8 +64,10 @@ test:
     - test -f $PREFIX/lib/libdart.dylib  # [osx]
     - test -f $PREFIX/lib/libdart.so  # [linux]
     - test -f $PREFIX/share/dart/cmake/dart_collision-odeTargets.cmake  # [not win]
+    - test -f $PREFIX/share/dart/cmake/dart_collision-bulletTargets.cmake  # [not win]
     - if not exist %LIBRARY_LIB%\\dart.lib exit 1  # [win]
     - if not exist %PREFIX%\\Library\\share\\dart\\cmake\\dart_collision-odeTargets.cmake exit 1  # [win]
+    - if not exist %PREFIX%\\Library\\share\\dart\\cmake\\dart_collision-bulletTargets.cmake exit 1  # [win]
 
 about:
   home: http://dartsim.github.io/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,6 +11,7 @@ source:
     patches:
       - 1478.patch  # [win]
       - 1541.patch  # [win]
+      - 1510.patch
       - ode-required.patch
 
 build:


### PR DESCRIPTION
Now the pure C++ bullet library is contained in the bullet-cpp package (see https://github.com/conda-forge/bullet-feedstock/pull/28). Furthermore, as in some downstream projects I will require the buller collision detector (see https://github.com/ignitionrobotics/ign-physics/pull/225 and https://github.com/ignitionrobotics/ign-physics/pull/239) better to apply Beyonce' Rule and add a test for it. 

Also, fix link with fcl and assimp by backporting https://github.com/dartsim/dart/pull/1510 .

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
