### PR TITLE
Resolve overlinking warnings

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,6 +15,8 @@ build:
     - {{ pin_subpackage(name, max_pin='x.x') }}
   ignore_run_exports:
     - console_bridge
+    - fmt       # [osx]
+    - libboost  # [osx]
     - spdlog
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,8 +15,11 @@ build:
     - {{ pin_subpackage(name, max_pin='x.x') }}
   ignore_run_exports:
     - console_bridge
-    - fmt       # [osx]
-    - libboost  # [osx]
+    - fmt           # [osx]
+    - freeglut      # [aarch64 or ppc64le]
+    - imgui         # [aarch64]
+    - libboost      # [osx]
+    - libstdcxx-ng  # [aarch64 or ppc64le]
     - spdlog
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,6 +13,9 @@ build:
   number: 0
   run_exports:
     - {{ pin_subpackage(name, max_pin='x.x') }}
+  ignore_run_exports:
+    - console_bridge
+    - spdlog
 
 requirements:
   build:
@@ -51,7 +54,11 @@ requirements:
 
   run:
     - eigen
+    - glfw
+    - libccd-double
     - octomap
+    - sdl2
+    - xorg-libxi
 
 test:
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
     sha256: f5fc7f5cb1269cc127a1ff69be26247b9f3617ce04ff1c80c0f3f6abc7d9ab70
 
 build:
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage(name, max_pin='x.x') }}
   ignore_run_exports:


### PR DESCRIPTION
https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=970999&view=logs&j=656edd35-690f-5c53-9ba3-09c10d0bea97&t=986b1512-c876-5f92-0d81-ba851554a0a3&l=3030

```
WARNING (dartsim,lib/libdart.so.6.14.4): Needed DSO lib/libccd.so.2 found in ['conda-forge/linux-64::libccd-double==2.1=h59595ed_3']
WARNING (dartsim,lib/libdart.so.6.14.4): .. but ['conda-forge/linux-64::libccd-double==2.1=h59595ed_3'] not in reqs/run, (i.e. it is overlinking) (likely) or a missing dependency (less likely)
...
WARNING (dartsim): run-exports library package conda-forge/linux-64::console_bridge==1.0.2=h924138e_1 in requirements/run but it is not used (i.e. it is overdepending or perhaps statically linked? If that is what you want then add it to `build/ignore_run_exports`)
WARNING (dartsim): run-exports library package conda-forge/linux-64::spdlog==1.13.0=hd2e6256_0 in requirements/run but it is not used (i.e. it is overdepending or perhaps statically linked? If that is what you want then add it to `build/ignore_run_exports`)
```

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
