### PR TITLE
Remove dartsim-cpp dependency from dartpy

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -8,8 +8,24 @@ jobs:
     vmImage: ubuntu-latest
   strategy:
     matrix:
-      linux_64_:
-        CONFIG: linux_64_
+      linux_64_numpy1.22python3.10.____cpython:
+        CONFIG: linux_64_numpy1.22python3.10.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+      linux_64_numpy1.22python3.9.____cpython:
+        CONFIG: linux_64_numpy1.22python3.9.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+      linux_64_numpy1.23python3.11.____cpython:
+        CONFIG: linux_64_numpy1.23python3.11.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+      linux_64_numpy1.26python3.12.____cpython:
+        CONFIG: linux_64_numpy1.26python3.12.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+      linux_64_numpy2python3.13.____cp313:
+        CONFIG: linux_64_numpy2python3.13.____cp313
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
       linux_aarch64_:

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -8,11 +8,35 @@ jobs:
     vmImage: macOS-13
   strategy:
     matrix:
-      osx_64_:
-        CONFIG: osx_64_
+      osx_64_numpy1.22python3.10.____cpython:
+        CONFIG: osx_64_numpy1.22python3.10.____cpython
         UPLOAD_PACKAGES: 'True'
-      osx_arm64_:
-        CONFIG: osx_arm64_
+      osx_64_numpy1.22python3.9.____cpython:
+        CONFIG: osx_64_numpy1.22python3.9.____cpython
+        UPLOAD_PACKAGES: 'True'
+      osx_64_numpy1.23python3.11.____cpython:
+        CONFIG: osx_64_numpy1.23python3.11.____cpython
+        UPLOAD_PACKAGES: 'True'
+      osx_64_numpy1.26python3.12.____cpython:
+        CONFIG: osx_64_numpy1.26python3.12.____cpython
+        UPLOAD_PACKAGES: 'True'
+      osx_64_numpy2python3.13.____cp313:
+        CONFIG: osx_64_numpy2python3.13.____cp313
+        UPLOAD_PACKAGES: 'True'
+      osx_arm64_numpy1.22python3.10.____cpython:
+        CONFIG: osx_arm64_numpy1.22python3.10.____cpython
+        UPLOAD_PACKAGES: 'True'
+      osx_arm64_numpy1.22python3.9.____cpython:
+        CONFIG: osx_arm64_numpy1.22python3.9.____cpython
+        UPLOAD_PACKAGES: 'True'
+      osx_arm64_numpy1.23python3.11.____cpython:
+        CONFIG: osx_arm64_numpy1.23python3.11.____cpython
+        UPLOAD_PACKAGES: 'True'
+      osx_arm64_numpy1.26python3.12.____cpython:
+        CONFIG: osx_arm64_numpy1.26python3.12.____cpython
+        UPLOAD_PACKAGES: 'True'
+      osx_arm64_numpy2python3.13.____cp313:
+        CONFIG: osx_arm64_numpy2python3.13.____cp313
         UPLOAD_PACKAGES: 'True'
   timeoutInMinutes: 360
   variables: {}

--- a/.ci_support/linux_64_numpy1.22python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.22python3.10.____cpython.yaml
@@ -1,0 +1,57 @@
+assimp:
+- 5.4.3
+bullet_cpp:
+- '3.25'
+c_compiler:
+- gcc
+c_compiler_version:
+- '13'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+cdt_name:
+- conda
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+console_bridge:
+- '1.0'
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '13'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+fmt:
+- '11'
+ipopt:
+- 3.14.17
+libboost_devel:
+- '1.86'
+libode:
+- 0.16.5
+nlopt:
+- '2.9'
+numpy:
+- '1.22'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.10.* *_cpython
+spdlog:
+- '1.14'
+target_platform:
+- linux-64
+tinyxml2:
+- '10'
+urdfdom:
+- '4.0'
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+- - python
+  - numpy

--- a/.ci_support/linux_64_numpy1.22python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.22python3.9.____cpython.yaml
@@ -1,0 +1,57 @@
+assimp:
+- 5.4.3
+bullet_cpp:
+- '3.25'
+c_compiler:
+- gcc
+c_compiler_version:
+- '13'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+cdt_name:
+- conda
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+console_bridge:
+- '1.0'
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '13'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+fmt:
+- '11'
+ipopt:
+- 3.14.17
+libboost_devel:
+- '1.86'
+libode:
+- 0.16.5
+nlopt:
+- '2.9'
+numpy:
+- '1.22'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.9.* *_cpython
+spdlog:
+- '1.14'
+target_platform:
+- linux-64
+tinyxml2:
+- '10'
+urdfdom:
+- '4.0'
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+- - python
+  - numpy

--- a/.ci_support/linux_64_numpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.23python3.11.____cpython.yaml
@@ -1,0 +1,57 @@
+assimp:
+- 5.4.3
+bullet_cpp:
+- '3.25'
+c_compiler:
+- gcc
+c_compiler_version:
+- '13'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+cdt_name:
+- conda
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+console_bridge:
+- '1.0'
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '13'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+fmt:
+- '11'
+ipopt:
+- 3.14.17
+libboost_devel:
+- '1.86'
+libode:
+- 0.16.5
+nlopt:
+- '2.9'
+numpy:
+- '1.23'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.11.* *_cpython
+spdlog:
+- '1.14'
+target_platform:
+- linux-64
+tinyxml2:
+- '10'
+urdfdom:
+- '4.0'
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+- - python
+  - numpy

--- a/.ci_support/linux_64_numpy1.26python3.12.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.26python3.12.____cpython.yaml
@@ -1,0 +1,57 @@
+assimp:
+- 5.4.3
+bullet_cpp:
+- '3.25'
+c_compiler:
+- gcc
+c_compiler_version:
+- '13'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+cdt_name:
+- conda
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+console_bridge:
+- '1.0'
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '13'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+fmt:
+- '11'
+ipopt:
+- 3.14.17
+libboost_devel:
+- '1.86'
+libode:
+- 0.16.5
+nlopt:
+- '2.9'
+numpy:
+- '1.26'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.12.* *_cpython
+spdlog:
+- '1.14'
+target_platform:
+- linux-64
+tinyxml2:
+- '10'
+urdfdom:
+- '4.0'
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+- - python
+  - numpy

--- a/.ci_support/linux_64_numpy2python3.13.____cp313.yaml
+++ b/.ci_support/linux_64_numpy2python3.13.____cp313.yaml
@@ -1,0 +1,57 @@
+assimp:
+- 5.4.3
+bullet_cpp:
+- '3.25'
+c_compiler:
+- gcc
+c_compiler_version:
+- '13'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+cdt_name:
+- conda
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+console_bridge:
+- '1.0'
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '13'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+fmt:
+- '11'
+ipopt:
+- 3.14.17
+libboost_devel:
+- '1.86'
+libode:
+- 0.16.5
+nlopt:
+- '2.9'
+numpy:
+- '2'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.13.* *_cp313
+spdlog:
+- '1.14'
+target_platform:
+- linux-64
+tinyxml2:
+- '10'
+urdfdom:
+- '4.0'
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+- - python
+  - numpy

--- a/.ci_support/osx_64_numpy1.22python3.10.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.22python3.10.____cpython.yaml
@@ -1,0 +1,59 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.15'
+MACOSX_SDK_VERSION:
+- '10.15'
+assimp:
+- 5.4.3
+bullet_cpp:
+- '3.25'
+c_compiler:
+- clang
+c_compiler_version:
+- '18'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '10.15'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+console_bridge:
+- '1.0'
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '18'
+fmt:
+- '11'
+ipopt:
+- 3.14.17
+libboost_devel:
+- '1.86'
+libode:
+- 0.16.5
+macos_machine:
+- x86_64-apple-darwin13.4.0
+nlopt:
+- '2.9'
+numpy:
+- '1.22'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.10.* *_cpython
+spdlog:
+- '1.14'
+target_platform:
+- osx-64
+tinyxml2:
+- '10'
+urdfdom:
+- '4.0'
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+- - python
+  - numpy

--- a/.ci_support/osx_64_numpy1.22python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.22python3.9.____cpython.yaml
@@ -1,17 +1,19 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.15'
+MACOSX_SDK_VERSION:
+- '10.15'
 assimp:
 - 5.4.3
 bullet_cpp:
 - '3.25'
 c_compiler:
-- gcc
+- clang
 c_compiler_version:
-- '13'
+- '18'
 c_stdlib:
-- sysroot
+- macosx_deployment_target
 c_stdlib_version:
-- '2.17'
-cdt_name:
-- conda
+- '10.15'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -19,11 +21,9 @@ channel_targets:
 console_bridge:
 - '1.0'
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '13'
-docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma9
+- '18'
 fmt:
 - '11'
 ipopt:
@@ -32,28 +32,22 @@ libboost_devel:
 - '1.86'
 libode:
 - 0.16.5
+macos_machine:
+- x86_64-apple-darwin13.4.0
 nlopt:
 - '2.9'
 numpy:
-- '1.22'
-- '1.23'
-- '1.26'
-- '2'
 - '1.22'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.10.* *_cpython
-- 3.11.* *_cpython
-- 3.12.* *_cpython
-- 3.13.* *_cp313
 - 3.9.* *_cpython
 spdlog:
 - '1.14'
 target_platform:
-- linux-64
+- osx-64
 tinyxml2:
 - '10'
 urdfdom:

--- a/.ci_support/osx_64_numpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.23python3.11.____cpython.yaml
@@ -1,7 +1,7 @@
 MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
+- '10.15'
 MACOSX_SDK_VERSION:
-- '11.0'
+- '10.15'
 assimp:
 - 5.4.3
 bullet_cpp:
@@ -13,7 +13,7 @@ c_compiler_version:
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
-- '11.0'
+- '10.15'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -33,29 +33,21 @@ libboost_devel:
 libode:
 - 0.16.5
 macos_machine:
-- arm64-apple-darwin20.0.0
+- x86_64-apple-darwin13.4.0
 nlopt:
 - '2.9'
 numpy:
-- '1.22'
 - '1.23'
-- '1.26'
-- '2'
-- '1.22'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.10.* *_cpython
 - 3.11.* *_cpython
-- 3.12.* *_cpython
-- 3.13.* *_cp313
-- 3.9.* *_cpython
 spdlog:
 - '1.14'
 target_platform:
-- osx-arm64
+- osx-64
 tinyxml2:
 - '10'
 urdfdom:

--- a/.ci_support/osx_64_numpy1.26python3.12.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.26python3.12.____cpython.yaml
@@ -1,0 +1,59 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.15'
+MACOSX_SDK_VERSION:
+- '10.15'
+assimp:
+- 5.4.3
+bullet_cpp:
+- '3.25'
+c_compiler:
+- clang
+c_compiler_version:
+- '18'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '10.15'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+console_bridge:
+- '1.0'
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '18'
+fmt:
+- '11'
+ipopt:
+- 3.14.17
+libboost_devel:
+- '1.86'
+libode:
+- 0.16.5
+macos_machine:
+- x86_64-apple-darwin13.4.0
+nlopt:
+- '2.9'
+numpy:
+- '1.26'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.12.* *_cpython
+spdlog:
+- '1.14'
+target_platform:
+- osx-64
+tinyxml2:
+- '10'
+urdfdom:
+- '4.0'
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+- - python
+  - numpy

--- a/.ci_support/osx_64_numpy2python3.13.____cp313.yaml
+++ b/.ci_support/osx_64_numpy2python3.13.____cp313.yaml
@@ -1,0 +1,59 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.15'
+MACOSX_SDK_VERSION:
+- '10.15'
+assimp:
+- 5.4.3
+bullet_cpp:
+- '3.25'
+c_compiler:
+- clang
+c_compiler_version:
+- '18'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '10.15'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+console_bridge:
+- '1.0'
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '18'
+fmt:
+- '11'
+ipopt:
+- 3.14.17
+libboost_devel:
+- '1.86'
+libode:
+- 0.16.5
+macos_machine:
+- x86_64-apple-darwin13.4.0
+nlopt:
+- '2.9'
+numpy:
+- '2'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.13.* *_cp313
+spdlog:
+- '1.14'
+target_platform:
+- osx-64
+tinyxml2:
+- '10'
+urdfdom:
+- '4.0'
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+- - python
+  - numpy

--- a/.ci_support/osx_arm64_numpy1.22python3.10.____cpython.yaml
+++ b/.ci_support/osx_arm64_numpy1.22python3.10.____cpython.yaml
@@ -1,0 +1,59 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+MACOSX_SDK_VERSION:
+- '11.0'
+assimp:
+- 5.4.3
+bullet_cpp:
+- '3.25'
+c_compiler:
+- clang
+c_compiler_version:
+- '18'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '11.0'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+console_bridge:
+- '1.0'
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '18'
+fmt:
+- '11'
+ipopt:
+- 3.14.17
+libboost_devel:
+- '1.86'
+libode:
+- 0.16.5
+macos_machine:
+- arm64-apple-darwin20.0.0
+nlopt:
+- '2.9'
+numpy:
+- '1.22'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.10.* *_cpython
+spdlog:
+- '1.14'
+target_platform:
+- osx-arm64
+tinyxml2:
+- '10'
+urdfdom:
+- '4.0'
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+- - python
+  - numpy

--- a/.ci_support/osx_arm64_numpy1.22python3.9.____cpython.yaml
+++ b/.ci_support/osx_arm64_numpy1.22python3.9.____cpython.yaml
@@ -1,7 +1,7 @@
 MACOSX_DEPLOYMENT_TARGET:
-- '10.15'
+- '11.0'
 MACOSX_SDK_VERSION:
-- '10.15'
+- '11.0'
 assimp:
 - 5.4.3
 bullet_cpp:
@@ -13,7 +13,7 @@ c_compiler_version:
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
-- '10.15'
+- '11.0'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -33,29 +33,21 @@ libboost_devel:
 libode:
 - 0.16.5
 macos_machine:
-- x86_64-apple-darwin13.4.0
+- arm64-apple-darwin20.0.0
 nlopt:
 - '2.9'
 numpy:
-- '1.22'
-- '1.23'
-- '1.26'
-- '2'
 - '1.22'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.10.* *_cpython
-- 3.11.* *_cpython
-- 3.12.* *_cpython
-- 3.13.* *_cp313
 - 3.9.* *_cpython
 spdlog:
 - '1.14'
 target_platform:
-- osx-64
+- osx-arm64
 tinyxml2:
 - '10'
 urdfdom:

--- a/.ci_support/osx_arm64_numpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/osx_arm64_numpy1.23python3.11.____cpython.yaml
@@ -1,0 +1,59 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+MACOSX_SDK_VERSION:
+- '11.0'
+assimp:
+- 5.4.3
+bullet_cpp:
+- '3.25'
+c_compiler:
+- clang
+c_compiler_version:
+- '18'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '11.0'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+console_bridge:
+- '1.0'
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '18'
+fmt:
+- '11'
+ipopt:
+- 3.14.17
+libboost_devel:
+- '1.86'
+libode:
+- 0.16.5
+macos_machine:
+- arm64-apple-darwin20.0.0
+nlopt:
+- '2.9'
+numpy:
+- '1.23'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.11.* *_cpython
+spdlog:
+- '1.14'
+target_platform:
+- osx-arm64
+tinyxml2:
+- '10'
+urdfdom:
+- '4.0'
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+- - python
+  - numpy

--- a/.ci_support/osx_arm64_numpy1.26python3.12.____cpython.yaml
+++ b/.ci_support/osx_arm64_numpy1.26python3.12.____cpython.yaml
@@ -1,0 +1,59 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+MACOSX_SDK_VERSION:
+- '11.0'
+assimp:
+- 5.4.3
+bullet_cpp:
+- '3.25'
+c_compiler:
+- clang
+c_compiler_version:
+- '18'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '11.0'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+console_bridge:
+- '1.0'
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '18'
+fmt:
+- '11'
+ipopt:
+- 3.14.17
+libboost_devel:
+- '1.86'
+libode:
+- 0.16.5
+macos_machine:
+- arm64-apple-darwin20.0.0
+nlopt:
+- '2.9'
+numpy:
+- '1.26'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.12.* *_cpython
+spdlog:
+- '1.14'
+target_platform:
+- osx-arm64
+tinyxml2:
+- '10'
+urdfdom:
+- '4.0'
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+- - python
+  - numpy

--- a/.ci_support/osx_arm64_numpy2python3.13.____cp313.yaml
+++ b/.ci_support/osx_arm64_numpy2python3.13.____cp313.yaml
@@ -1,0 +1,59 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+MACOSX_SDK_VERSION:
+- '11.0'
+assimp:
+- 5.4.3
+bullet_cpp:
+- '3.25'
+c_compiler:
+- clang
+c_compiler_version:
+- '18'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '11.0'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+console_bridge:
+- '1.0'
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '18'
+fmt:
+- '11'
+ipopt:
+- 3.14.17
+libboost_devel:
+- '1.86'
+libode:
+- 0.16.5
+macos_machine:
+- arm64-apple-darwin20.0.0
+nlopt:
+- '2.9'
+numpy:
+- '2'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.13.* *_cp313
+spdlog:
+- '1.14'
+target_platform:
+- osx-arm64
+tinyxml2:
+- '10'
+urdfdom:
+- '4.0'
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+- - python
+  - numpy

--- a/README.md
+++ b/README.md
@@ -31,10 +31,38 @@ Current build status
         <table>
           <thead><tr><th>Variant</th><th>Status</th></tr></thead>
           <tbody><tr>
-              <td>linux_64</td>
+              <td>linux_64_numpy1.22python3.10.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=10922&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/dartsim-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/dartsim-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_numpy1.22python3.10.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_numpy1.22python3.9.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=10922&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/dartsim-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_numpy1.22python3.9.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_numpy1.23python3.11.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=10922&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/dartsim-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_numpy1.23python3.11.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_numpy1.26python3.12.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=10922&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/dartsim-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_numpy1.26python3.12.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_numpy2python3.13.____cp313</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=10922&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/dartsim-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_numpy2python3.13.____cp313" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -52,17 +80,73 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64</td>
+              <td>osx_64_numpy1.22python3.10.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=10922&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/dartsim-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/dartsim-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_numpy1.22python3.10.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_arm64</td>
+              <td>osx_64_numpy1.22python3.9.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=10922&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/dartsim-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/dartsim-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_numpy1.22python3.9.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_numpy1.23python3.11.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=10922&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/dartsim-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_numpy1.23python3.11.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_numpy1.26python3.12.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=10922&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/dartsim-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_numpy1.26python3.12.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_numpy2python3.13.____cp313</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=10922&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/dartsim-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_numpy2python3.13.____cp313" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_numpy1.22python3.10.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=10922&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/dartsim-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_numpy1.22python3.10.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_numpy1.22python3.9.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=10922&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/dartsim-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_numpy1.22python3.9.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_numpy1.23python3.11.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=10922&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/dartsim-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_numpy1.23python3.11.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_numpy1.26python3.12.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=10922&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/dartsim-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_numpy1.26python3.12.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_numpy2python3.13.____cp313</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=10922&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/dartsim-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_numpy2python3.13.____cp313" alt="variant">
                 </a>
               </td>
             </tr><tr>

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
     sha256: bbf954e283f464f6d0a8a5ab43ce92fd49ced357ccdd986c7cb4c29152df8692
 
 build:
-  number: 2
+  number: 3
 
 outputs:
   - name: dartsim-cpp
@@ -98,21 +98,30 @@ outputs:
         - numpy                               # [build_platform != target_platform]
         - python                              # [build_platform != target_platform]
       host:
-        - {{ pin_subpackage('dartsim-cpp', exact=True) }}
         # C++ deps
         - assimp
         - bullet-cpp
+        - console_bridge
+        - eigen
         - fcl
-        - libgl  # [linux]
+        - fmt
+        - freeglut  # [not osx]
+        - imgui
+        - ipopt
+        - libboost-devel
         - libode
+        - libgl  # [linux]
         - nlopt
         - octomap
         - openscenegraph
+        - pagmo
+        - pagmo-devel
         - tinyxml2
         - urdfdom
-        - numpy
+        - spdlog
         - xorg-libxfixes  # [linux]
         # Python deps
+        - numpy
         - pip
         - python
         - requests
@@ -121,7 +130,6 @@ outputs:
         - {{ cdt('mesa-libgl-devel') }}   # [linux64]
         - {{ cdt('mesa-libglu-devel') }}  # [linux64]
         - {{ cdt('mesa-dri-drivers') }}   # [linux]
-        - {{ pin_subpackage('dartsim-cpp', exact=True) }}
         - libgl   # [linux]
         - libglu  # [linux]
         - numpy


### PR DESCRIPTION
`dartpy` depends on static libraries of DART, so it doesn't need to depend on `dartsim-cpp` (i.e., shared libraries).

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
