### PR TITLE
Fix dartsim dependency

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -147,7 +147,8 @@ outputs:
         - numpy
     test:
       imports:
-        - dartpy
+        - dartpy  # [linux and x86_64]
+        - dartpy  # [osx and x86_64]
       commands:
         - test -f $PREFIX/lib/libdart.dylib  # [osx]
         - test -f $PREFIX/lib/libdart.so  # [linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -141,7 +141,8 @@ outputs:
     requirements:
       run:
         - {{ pin_subpackage('dartsim-cpp', exact=True) }}
-        - {{ pin_subpackage('dartpy', exact=True) }}
+        - {{ pin_subpackage('dartpy', exact=True) }}  # [linux and x86_64]
+        - {{ pin_subpackage('dartpy', exact=True) }}  # [osx and x86_64]
         - python
         - numpy
     test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
       - remove-opencl.patch
 
 build:
-  number: 6
+  number: 7
 
 outputs:
   - name: dartsim-cpp


### PR DESCRIPTION
`dartsim` should have `dartpy` dependency only for the supported platforms

Related: #103

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
