### PR TITLE
Reduce Windows dartpy build matrix

### DIFF
--- a/recipe/bld_py.bat
+++ b/recipe/bld_py.bat
@@ -7,18 +7,18 @@ if exist build rmdir /s /q build
 :: Use a build temp directory on the system drive to avoid D: disk exhaustion
 set "DARTPY_BUILD_TEMP=%USERPROFILE%\\AppData\\Local\\Temp\\dartpy_build"
 
-:: Avoid MSVC release flags that add /Zi and /GL (big memory spikes)
+:: Avoid DART's MSVC release flags that add /Zi and /GL (big memory spikes).
 :: Use conda-forge's pybind11 package instead of CMake FetchContent.
-set "CMAKE_ARGS=%CMAKE_ARGS% -DDART_MSVC_DEFAULT_OPTIONS=ON -DDART_USE_SYSTEM_PYBIND11=ON"
+set "CMAKE_ARGS=%CMAKE_ARGS% -DDART_MSVC_DEFAULT_OPTIONS=ON"
+set "CMAKE_ARGS=%CMAKE_ARGS% -DDART_USE_SYSTEM_PYBIND11=ON"
 
-:: Compiler flags to reduce memory usage:
-:: - /Od         => disable optimizations
+:: Compiler flags to reduce memory usage while keeping Release optimization:
 :: - /Zm2000     => increase compiler heap (change if needed)
 :: - /bigobj     => allow larger .obj files
 :: - (NO /Z7)    => no debug symbols
 :: - (NO /GL)    => ensure LTCG is off
-set "CL=%CL% /Od /Zm2000 /bigobj"
-set CXXFLAGS=%CXXFLAGS% /Od /Zm2000 /bigobj
+set "CL=%CL% /Zm2000 /bigobj"
+set CXXFLAGS=%CXXFLAGS% /Zm2000 /bigobj
 
 :: Install the Python package (triggers CMake build via pip)
 python -m pip install . -vv --no-deps --no-build-isolation

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -3,7 +3,7 @@ schema_version: 1
 context:
   name: dartsim
   version: "6.19.3"
-  build_number: 0
+  build_number: 1
 
 recipe:
   name: ${{ name|lower }}-split
@@ -113,7 +113,10 @@ outputs:
       script:
         file: ${{ "bld_py.bat" if win else "build_py.sh" }}
       skip:
-        - (linux and match(python, "<3.12")) or (win and (match(python, "<3.12") or match(python, ">3.14")))
+        # dartpy rebuilds DART for each Python variant on Windows; keep the
+        # latest Python variants first (currently 3.14 and 3.13) while staying
+        # under Azure's 6h job timeout with optimized Release builds.
+        - (linux and match(python, "<3.12")) or (win and (match(python, "<3.13") or match(python, ">3.14")))
     requirements:
       build:
         - ${{ compiler('c') }}
@@ -182,7 +185,7 @@ outputs:
       name: dartsim
     build:
       skip:
-        - (linux and match(python, "<3.12")) or (win and (match(python, "<3.12") or match(python, ">3.14")))
+        - (linux and match(python, "<3.12")) or (win and (match(python, "<3.13") or match(python, ">3.14")))
     requirements:
       run:
         - ${{ pin_subpackage('dartsim-cpp', exact=True) }}


### PR DESCRIPTION
## Summary
- keep Windows `dartpy` Release builds optimized instead of overriding CMake Release flags
- skip the oldest Windows Python variant, so win-64 builds `dartpy`/`dartsim` for Python 3.13 and 3.14
- keep the existing MSVC memory mitigations that avoid DART's extra `/Zi` and `/GL` defaults, and bump the build number to 1

## Rationale
The failed Azure win-64 build timed out after 360 minutes while compiling the third `dartpy` variant. In DART 6.19.3, `dartpy` rebuilds the DART C++ targets for each Python variant, so the Windows job was effectively doing one `dartsim-cpp` build plus three optimized `dartpy` builds. Dropping the oldest Windows Python variant reduces one full `dartpy` rebuild while preserving optimized Release code for the produced packages.

A better long-term fix would be upstream support for building `dartpy` against an installed DART C++ package, but that path is not available in the 6.19.3 build system.

## Checks
- `CONDA_OVERRIDE_WIN=10.0.20348 pixi run rattler-build build --recipe recipe -m .ci_support/win_64_.yaml --target-platform win-64 --build-platform win-64 --render-only --with-solve --log-style plain`
- `pixi run rerender`
- `pixi run lint` (passes with the existing free-disk-space deprecation suggestion)
- `git diff --check`